### PR TITLE
Specialize filter_iter using const generic instead of macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ clap = "2.32.0"
 time = "0.1.40"
 itertools = "0.7.8"
 libc = "0.2.43"
+typenum = "1.10.0"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ extern crate rayon;
 extern crate crc;
 extern crate libz_sys;
 #[macro_use] extern crate itertools;
+extern crate typenum;
 
 // @fixme use a feature flag or?
 extern crate libc;


### PR DESCRIPTION
Hi, I recently read your very good blog posts about `mtpng` and thought that maybe you didn't know about the excellent create [typenum](https://crates.io/crates/typenum) when you wrote your article about constant specialization.

This PR is about using this crate to solve the same problem exposed in this blog post: https://brionv.com/log/2018/09/12/parallelizing-png-part-8-rust-macros-for-constant-specialization/

---

Since real const generics are not implemented yet (RFC2000),
we use the widely used typenum create which fills the gap
quite elegantly.

Monomorphization of this function is now semantically explicit
to Rust and does not anymore rely on an LLVM optimization pass
which might break at anytime in the future.