### PR TITLE
Compression level setter for C-API

### DIFF
--- a/c/mtpng.h
+++ b/c/mtpng.h
@@ -79,6 +79,15 @@ typedef enum mtpng_strategy_t {
 } mtpng_strategy;
 
 //
+// Compression levels for mtpng_encoder_options_set_compression_level().
+//
+typedef enum mtpng_compression_level_t {
+    MTPNG_COMPRESSION_LEVEL_FAST = 1,
+    MTPNG_COMPRESSION_LEVEL_DEFAULT = 6,
+    MTPNG_COMPRESSION_LEVEL_HIGH = 9
+} mtpng_compression_level;
+
+//
 // Color types for mtpng_encoder_set_color().
 //
 typedef enum mtpng_color_t {
@@ -277,6 +286,15 @@ mtpng_encoder_options_set_filter(mtpng_encoder_options* p_options,
 extern mtpng_result
 mtpng_encoder_options_set_strategy(mtpng_encoder_options* p_options,
                                    mtpng_strategy strategy_mode);
+
+//
+// Override the default PNG compression level.
+//
+// Check the return value for errors.
+//
+extern mtpng_result
+mtpng_encoder_options_set_compression_level(mtpng_encoder_options* p_options,
+                                            mtpng_compression_level compression_level);
 
 //
 // Override the default chunk size for parallel encoding

--- a/c/mtpng.h
+++ b/c/mtpng.h
@@ -26,6 +26,10 @@
 #ifndef MTPNG_H_INCLUDED
 #define MTPNG_H_INCLUDED 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -518,5 +522,8 @@ mtpng_encoder_finish(mtpng_encoder** pp_encoder);
 
 #pragma mark footer
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MTPNG_H_INCLUDED */

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -36,6 +36,7 @@ use libc::{c_void, c_int, size_t};
 
 use super::ColorType;
 use super::Strategy;
+use super::CompressionLevel;
 use super::Mode::{Adaptive, Fixed};
 use super::Header;
 
@@ -300,6 +301,24 @@ fn mtpng_encoder_options_set_strategy(p_options: PEncoderOptions,
             Fixed(Strategy::try_from(strategy_mode as u8)?)
         };
         (*p_options).set_strategy_mode(mode)
+    }())
+}
+
+#[no_mangle]
+pub unsafe extern "C"
+fn mtpng_encoder_options_set_compression_level(p_options: PEncoderOptions,
+                                               compression_level: c_int)
+-> CResult
+{
+    CResult::from(|| -> io::Result<()> {
+        if p_options.is_null() {
+            return Err(invalid_input("p_options must not be null"));
+        }
+        if compression_level < 0 || compression_level > 9 {
+            return Err(invalid_input("Invalid compression level"));
+        }
+        let level = CompressionLevel::try_from(compression_level as u8)?;
+        (*p_options).set_compression_level(level)
     }())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,3 +344,19 @@ pub enum CompressionLevel {
     /// Best compression but slow (zlib level 9).
     High
 }
+
+impl TryFrom<u8> for CompressionLevel {
+    type Error = io::Error;
+
+    /// Validate and convert u8 to CompressionLevel.
+    ///
+    /// Will return an error on invalid input.
+    fn try_from(val: u8) -> Result<Self, Self::Error> {
+        match val {
+            1 => Ok(CompressionLevel::Fast),
+            6 => Ok(CompressionLevel::Default),
+            9 => Ok(CompressionLevel::High),
+            _ => Err(invalid_input("Compression level not supported")),
+        }
+    }
+}


### PR DESCRIPTION
Added another c-api export for setting the `compression_level` encoder option.

Also added a `extern "C"` guard to the header which C++ requires for linking.