### PR TITLE
Use crc32fast crate instead of crc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ required-features=["cli"]
 
 [dependencies]
 rayon = "1.0.2"
-crc = "1.8.1"
+crc32fast = "1.2"
 libz-sys = "1.0.23"
 itertools = "0.7.8"
 typenum = "1.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! mtpng - a multithreaded parallel PNG encoder in Rust
 
 extern crate rayon;
-extern crate crc;
+extern crate crc32fast;
 extern crate libz_sys;
 #[macro_use] extern crate itertools;
 extern crate typenum;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -23,9 +23,6 @@
 // THE SOFTWARE.
 //
 
-use crc::crc32;
-use crc::Hasher32;
-
 use std::io;
 use std::io::Write;
 
@@ -102,10 +99,10 @@ impl<W: Write> Writer<W> {
         }
 
         // CRC covers both tag and data.
-        let mut digest = crc32::Digest::new(crc32::IEEE);
-        digest.write(tag);
-        digest.write(data);
-        let checksum = digest.sum32();
+        let mut digest = crc32fast::Hasher::new();
+        digest.update(tag);
+        digest.update(data);
+        let checksum = digest.finalize();
 
         // Write data...
         self.write_be32(data.len() as u32)?;


### PR DESCRIPTION
See https://crates.io/crates/crc32fast for benchmark data.
The speedup is noticeable when the image is multiple MBs. Tests on my machine show 5% faster on 8MB screenshot.
