### PR TITLE
Add zlib-ng feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["multimedia::images"]
 default=[]
 cli=["png", "clap", "time"]
 capi=["libc"]
+zlib-ng=["libz-sys/zlib-ng"]
 
 [[bin]]
 name="mtpng"
@@ -23,7 +24,7 @@ required-features=["cli"]
 [dependencies]
 rayon = "1.0.2"
 crc = "1.8.1"
-libz-sys = "1.0.23"
+libz-sys = { version = "1.1", default-features = false, features = ["libc"] }
 itertools = "0.7.8"
 typenum = "1.10.0"
 

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -52,7 +52,7 @@ pub fn adler32_initial() -> u32 {
 
 pub fn adler32_combine(sum_a: u32, sum_b: u32, len_b: usize) -> u32 {
     unsafe {
-        ::libz_sys::adler32_combine(c_ulong::from(sum_a), c_ulong::from(sum_b), len_b as c_long) as u32
+        ::libz_sys::adler32_combine(c_ulong::from(sum_a), c_ulong::from(sum_b), len_b as z_off_t) as u32
     }
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/libz-sys#zlib-ng
Enabling this feature flag changes the libz backend to the heavily optimized zlib-ng.