### PR TITLE
Avoid panicking on Encoder drop

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -731,7 +731,7 @@ impl<'a, W: Write> Encoder<'a, W> {
                         tx.send(match deflate.run() {
                             Ok(()) => ThreadMessage::DeflateDone(Arc::new(deflate)),
                             Err(e) => ThreadMessage::Error(e),
-                        }).unwrap();
+                        }).ok();
                     });
                 },
                 None => {
@@ -754,7 +754,7 @@ impl<'a, W: Write> Encoder<'a, W> {
                         tx.send(match filter.run() {
                             Ok(()) => ThreadMessage::FilterDone(Arc::new(filter)),
                             Err(e) => ThreadMessage::Error(e),
-                        }).unwrap();
+                        }).ok();
                     });
                 },
                 None => {


### PR DESCRIPTION
# This PR
This pull request changes two lines in `encoder.rs`, preventing rayon threads that are still running when their `Encoder` is dropped from panicking when they try to send their deflated/filtered data. The two lines changed replace the `unwrap()` calls on the rayon threads' `Sender`s' `send()` results with `ok()` calls, essentially ignoring whether the send operation was successful.

# Linked Issues
This PR should close #22.

# Notes
This is a quick fix. Let me know if you think something else would be a better idea here.