### PR TITLE
Allow using zlib-rs for more than 2x speedup and improved memory safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,16 @@ categories = ["multimedia::images"]
 [features]
 
 # Rust-only
-default=[]
+default=["zlib-rs"]
+
+# use zlib-rs, a Rust implementation of zlib API that's safer and much faster than the C one
+zlib-rs = ["libz-rs-sys"]
+
+# Use plain old zlib that's slow and not memory-safe.
+# Use this together with `--no-default-features` to avoid linking conflicts
+# when using C API when other parts of the C program also use plain old zlib.
+# If both zlib and zlib-rs features are enabled (e.g. via --all-features), zlib-rs is used.
+zlib = ["libz-sys"]
 
 # include command-line tool
 cli=["png", "clap", "time"]
@@ -29,7 +38,6 @@ required-features=["cli"]
 [dependencies]
 rayon = "1.5.0"
 crc = "1.8.1"
-libz-sys = "1.0.23"
 itertools = "0.10.0"
 
 # implied deps for cli
@@ -39,6 +47,10 @@ time = { version = "0.3.9", optional = true }
 
 # implied deps for capi
 libc = { version = "0.2.43", optional = true }
+
+
+libz-rs-sys = { version = "0.4.0", optional = true }
+libz-sys = { version = "1.0.23", optional = true }
 
 [lib]
 crate-type = ["rlib", "cdylib", "staticlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ libc = { version = "0.2.43", optional = true }
 
 
 libz-rs-sys = { version = "0.4.0", optional = true }
-libz-sys = { version = "1.0.23", optional = true }
+libz-sys = { version = "1.0.23", default-features = false, features = ["libc"], optional = true }
 
 [lib]
 crate-type = ["rlib", "cdylib", "staticlib"]

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -34,25 +34,31 @@ use std::convert::TryFrom;
 
 use std::os::raw::*;
 
-use ::libz_sys::*;
+#[cfg(feature = "zlib-rs")]
+use libz_rs_sys as libz_sys;
+#[cfg(feature = "zlib-rs")]
+use libz_rs_sys::*;
+#[cfg(all(feature = "zlib", not(feature = "zlib-rs")))]
+use libz_sys::*;
 
 use super::utils::*;
 
 pub fn adler32(sum: u32, bytes: &[u8]) -> u32 {
     unsafe {
-        ::libz_sys::adler32(c_ulong::from(sum), &bytes[0], bytes.len() as c_uint) as u32
+        libz_sys::adler32(c_ulong::from(sum), &bytes[0], bytes.len() as c_uint) as u32
     }
 }
 
 pub fn adler32_initial() -> u32 {
     unsafe {
-        ::libz_sys::adler32(0, ptr::null(), 0) as u32
+        libz_sys::adler32(0, ptr::null(), 0) as u32
     }
 }
 
 pub fn adler32_combine(sum_a: u32, sum_b: u32, len_b: usize) -> u32 {
+    #[allow(unused_unsafe)] // this function is marked safe in libz-rs-sys
     unsafe {
-        ::libz_sys::adler32_combine(c_ulong::from(sum_a), c_ulong::from(sum_b), len_b as c_long) as u32
+        libz_sys::adler32_combine(c_ulong::from(sum_a), c_ulong::from(sum_b), len_b as c_long) as u32
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,13 @@
 
 extern crate rayon;
 extern crate crc;
+
+// Select the zlib implementation
+#[cfg(feature = "zlib-rs")]
+extern crate libz_rs_sys;
+#[cfg(all(feature = "zlib", not(feature = "zlib-rs")))]
 extern crate libz_sys;
+
 #[macro_use] extern crate itertools;
 
 #[cfg(feature="capi")]


### PR DESCRIPTION
Switches over to [zlib-rs](https://github.com/trifectatechfoundation/zlib-rs) by default. On my machine this improves the reported time by `mtpng` CLI from 128ms to 55ms on this image: https://commons.wikimedia.org/wiki/File:Diagram_Integrasi_Transportasi_Publik_Semarang.png

Allows selecting plain old zlib via Cargo features just in case it's needed for some sort of C program linking not to blow up. I don't actually know if they will blow up or not, so I decided to err on the side of caution.