### PR TITLE
Fix start_row/end_row logic

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1099,15 +1099,11 @@ mod tests {
     }
     
     #[test]
-    fn test_chunk_size_less_than_one_row() {
+    fn small_chunk_size_relative_to_row_length() {
         let mut options = Options::new();
         options.set_chunk_size(256 * 1024).expect("Chunk size is at least 32 KiB");
         
         test_encoder_with_options((256 + 1) * 1024, 256, options, |encoder, data| {
-            assert_eq!(encoder.is_finished(), false);
-            assert_eq!(encoder.progress(), 0.0);
-
-            // We must finish out the file or it'll whinge.
             for _y in 0 .. 256 {
                 encoder.write_image_rows(data)?;
             }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -818,7 +818,7 @@ impl<'a, W: Write> Encoder<'a, W> {
         self.header = *header;
         
         let chunk_size = self.options.chunk_size;
-        let stride = self.header.stride();
+        let stride = self.header.stride() + 1;
         let height = self.header.height as usize;
         
         self.rows_per_chunk = chunk_size.div_ceil(stride);


### PR DESCRIPTION
Fixes #30.

I was able to fix the issue by rounding the chunk size to a multiple of the stride and reframing the arithmetic around the number of rows per chunk.

I ran this on the samples and pngsuite and compared the results with the latest version. Of the 40 test cases, 24 were binary identical, 16 had binary differences, and 0 had differences in pixel data. The total size of all the samples was about 1.5 KiB less after the change. I did not compare speed.